### PR TITLE
Update version to 1.0.0 in build files and README

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
 
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use JxRequest in your project, add the following dependency to your `pom.xml`
 <dependency>
     <groupId>io.github.swnck</groupId>
     <artifactId>jxrequest</artifactId>
-    <version>2.0.0</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 
@@ -54,7 +54,7 @@ If you're using Gradle, add the following to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'io.github.swnck:jxrequest:2.0.0'
+    implementation 'io.github.swnck:jxrequest:1.0.0'
 }
 ```
 If you're using a different build tool, you can download the JAR file from the [releases page](https://github.com/swnck/JxRequest/releases) and add it to your classpath manually.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.github.swnck"
-version = "2.0.0"
+version = "1.0.0"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This pull request includes two changes: one to ensure the Gradle wrapper is executable in the GitHub Actions workflow and another to correct the version of the `jxrequest` dependency in the documentation.

### Workflow improvement:
* [`.github/workflows/gradle-publish.yml`](diffhunk://#diff-2511803f9c29912d7f11dea9dade7a2272cfe322c681a8bff3727044db19e633R28-R30): Added a step to ensure the Gradle wrapper (`gradlew`) is executable by running `chmod +x ./gradlew` before the build step.

### Documentation update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R57): Corrected the `jxrequest` dependency version from `2.0.0` to `1.0.0` in both the Maven and Gradle examples.