### PR TITLE
Update environment variable name for GitHub token in CI workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -35,4 +35,4 @@ jobs:
         run: ./gradlew publish
         env:
           USERNAME: ${{ github.actor }}
-          TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/gradle-publish.yml` file. The change updates the environment variable used for authentication during the Gradle publish process.

* Workflow configuration update:
  * [`.github/workflows/gradle-publish.yml`](diffhunk://#diff-2511803f9c29912d7f11dea9dade7a2272cfe322c681a8bff3727044db19e633L38-R38): Replaced the `TOKEN` environment variable with `GITHUB_TOKEN` for consistency with GitHub Actions conventions.