### PR TITLE
Refactor AbstractRequest to use setter for URL; simplify JxRequestTes…

### DIFF
--- a/src/main/java/io/github/swnck/request/AbstractRequest.java
+++ b/src/main/java/io/github/swnck/request/AbstractRequest.java
@@ -24,7 +24,8 @@ public abstract class AbstractRequest<T extends AbstractRequest<T>> {
 
     public AbstractRequest(String url, Method method) {
         this.method = method;
-        this.url = url;
+
+        this.setUrl(url);
     }
 
     public AbstractRequest(Method method) {

--- a/src/test/java/io/github/swnck/JxRequestTest.java
+++ b/src/test/java/io/github/swnck/JxRequestTest.java
@@ -9,11 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class JxRequestTest {
     @Test
     void get() {
-        GetRequest jxRequest = JxRequest.get()
-                .setUrl("google.com");
+        GetRequest jxRequest = JxRequest.get("google.com");
 
         JxResponse response = jxRequest.send();
-        System.out.println(response.toString());
         assertNotNull(response);
     }
 


### PR DESCRIPTION
This pull request refactors URL handling in the `AbstractRequest` class and updates its usage in the `JxRequestTest` unit test. The changes aim to streamline the API and improve code clarity.

### Refactoring of URL handling:

* [`AbstractRequest.java`](diffhunk://#diff-ac9b6f5cb26c40bde2fc582c3440f7cbed93adf885b52196b07b725d9ffb4849L27-R28): Replaced direct assignment of the `url` field with the `setUrl` method in the constructor to enforce consistent URL handling.

### Updates to unit tests:

* [`JxRequestTest.java`](diffhunk://#diff-ac162cc98190fa32c4fdbc2960f3e4707898a9e33951aaaf954ffc8d44803367L12-L16): Simplified the `GetRequest` instantiation by introducing a new `JxRequest.get(String url)` method, removing the need for a separate `setUrl` call. Additionally, removed an unnecessary `System.out.println` statement from the test.