### PR TITLE
Bump version to 1.0.3 in build files because of package cache

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew build
 
       - name: Publish to GitHub Packages
-        run: ./gradlew publish
+        run: ./gradlew clean publish
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.github.swnck"
-version = "1.0.2"
+version = "1.0.3"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This pull request includes a small change to the `gradle-publish.yml` workflow file. The change ensures a clean build by adding the `clean` task before publishing to GitHub Packages.